### PR TITLE
Support for EEPROM config saving and auto-dump of data upon connection

### DIFF
--- a/ED_BMSdiag/ED_BMSdiag.h
+++ b/ED_BMSdiag/ED_BMSdiag.h
@@ -69,7 +69,7 @@ typedef struct {
 
 deviceStatus_t myDevice;
 
-enum {EE_Signature = 0, EE_IntialDumpAll, EE_logging, EE_logInterval, EE_Experimental};
+enum {EE_Signature = 0, EE_InitialDumpAll, EE_logging, EE_logInterval, EE_Experimental};
 const byte kMagicSignature = 0x55;
 
 void ReadGlobalConfig(deviceStatus_t *config, bool force_write = false);

--- a/ED_BMSdiag/ED_BMSdiag.h
+++ b/ED_BMSdiag/ED_BMSdiag.h
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------
-// (c) 2015-2017 by MyLab-odyssey
+// (c) 2015-2018 by MyLab-odyssey
 //
 // Licensed under "MIT License (MIT)", see license file for more information.
 //
@@ -16,9 +16,9 @@
 //--------------------------------------------------------------------------------
 //! \file    ED_BMSdiag.h
 //! \brief   Definitions and structures for the main program ED_BMSdiag.ino
-//! \date    2017-December
+//! \date    2018-February
 //! \author  MyLab-odyssey
-//! \version 1.0.4
+//! \version 1.0.5
 //--------------------------------------------------------------------------------
 
 #define VERBOSE 1                //!< VERBOSE mode will output individual cell data
@@ -35,7 +35,7 @@
 #include "canDiag.h"
 
 //Global definitions
-char* const PROGMEM version = "1.0.4";
+char* const PROGMEM version = (char *) "1.0.5";
 #define FAILURE F("* Measurement failed *")
 #define MSG_OK F("OK")
 #define MSG_FAIL F("F")
@@ -72,5 +72,5 @@ deviceStatus_t myDevice;
 enum {EE_Signature = 0, EE_IntialDumpAll, EE_logging, EE_logInterval, EE_Experimental};
 const byte kMagicSignature = 0x55;
 
-boolean ReadGlobalConfig(deviceStatus_t *config, bool force_write = false);
+void ReadGlobalConfig(deviceStatus_t *config, bool force_write = false);
 

--- a/ED_BMSdiag/ED_BMSdiag.ino
+++ b/ED_BMSdiag/ED_BMSdiag.ino
@@ -308,13 +308,13 @@ void ReadGlobalConfig(deviceStatus_t *config, bool force_write)
   // If the EEPROM hasn't been programmed yet, program it
   if (force_write || EEPROM.read(EE_Signature) != kMagicSignature) {
     Serial.println("Setting factory defaults");
-    EEPROM.update(EE_IntialDumpAll, 1); 
+    EEPROM.update(EE_InitialDumpAll, 1); 
     EEPROM.update(EE_logging, 0);
     EEPROM.update(EE_logInterval, 30);
     EEPROM.update(EE_Experimental, 0);
     EEPROM.update(EE_Signature, kMagicSignature);
   }
-  config->initialDump = (EEPROM.read(EE_IntialDumpAll) > 0);
+  config->initialDump = (EEPROM.read(EE_InitialDumpAll) > 0);
   config->logging = (EEPROM.read(EE_logging) > 0);
   config->timer = EEPROM.read(EE_logInterval);
   config->experimental = (EEPROM.read(EE_Experimental) > 0);

--- a/ED_BMSdiag/ED_BMSdiag.ino
+++ b/ED_BMSdiag/ED_BMSdiag.ino
@@ -1,8 +1,8 @@
 //--------------------------------------------------------------------------------
-// ED BMSdiag, v1.0.3
+// ED BMSdiag, v1.0.5
 // Retrieve battery diagnostic data from your smart electric drive EV.
 //
-// (c) 2015-2017 by MyLab-odyssey
+// (c) 2015-2018 by MyLab-odyssey
 //
 // Licensed under "MIT License (MIT)", see license file for more information.
 //
@@ -22,9 +22,9 @@
 //! \brief   Only usable for third gen. model build from late 2012 to mid 2015!!!
 //! \brief   Build a diagnostic tool with the MCP2515 CAN controller and Arduino
 //! \brief   compatible hardware.
-//! \date    2017-December
+//! \date    2018-February
 //! \author  MyLab-odyssey
-//! \version 1.0.3
+//! \version 1.0.5
 //--------------------------------------------------------------------------------
 #include "ED_BMSdiag.h"
 
@@ -84,7 +84,7 @@ void setup() {
   // For convenience of users, dump all data first (same as "all" from top-level menu)
   // Do this after the setupMenu() call.
   if (myDevice.initialDump)
-    get_all(0, (void**) 0L);
+    get_all(0, (char**) 0L);
 
   //Print standard data set as overview
   printSplashScreen();
@@ -303,7 +303,7 @@ boolean getCLSdata() {
 }
 
 
-boolean ReadGlobalConfig(deviceStatus_t *config, bool force_write = false)
+void ReadGlobalConfig(deviceStatus_t *config, bool force_write)
 {
   // If the EEPROM hasn't been programmed yet, program it
   if (force_write || EEPROM.read(EE_Signature) != kMagicSignature) {

--- a/ED_BMSdiag/ED_BMSdiag_CLI.ino
+++ b/ED_BMSdiag/ED_BMSdiag_CLI.ino
@@ -1,5 +1,5 @@
 //--------------------------------------------------------------------------------
-// (c) 2015-2017 by MyLab-odyssey
+// (c) 2015-2018 by MyLab-odyssey
 //
 // Licensed under "MIT License (MIT)", see license file for more information.
 //
@@ -16,9 +16,9 @@
 //--------------------------------------------------------------------------------
 //! \file    ED_BMSdiag_CLI.ino
 //! \brief   Functions for the Command Line Interface (CLI) menu system
-//! \date    2017-December
+//! \date    2018-February
 //! \author  MyLab-odyssey
-//! \version 1.0.3
+//! \version 1.0.5
 //--------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------
@@ -56,6 +56,7 @@ void setupMenu() {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_all (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   switch (myDevice.menu) {
     case subBMS:
       printBMSall();
@@ -80,6 +81,7 @@ void get_all (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_rpt (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   printRPT();
 }
 
@@ -88,6 +90,7 @@ void get_rpt (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_temperatures (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   switch (myDevice.menu) {
     case subBMS:
       if (DiagCAN.getBatteryTemperature(&BMS, false)){
@@ -112,6 +115,7 @@ void get_temperatures (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_voltages (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   switch (myDevice.menu) {
     case subBMS:
       if (DiagCAN.getBatteryADCref(&BMS, false)){
@@ -139,6 +143,7 @@ void get_voltages (uint8_t arg_cnt, char **args) {
 #ifdef HELP
 void help(uint8_t arg_cnt, char **args)
 {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   switch (myDevice.menu) {
     case MAIN:
       Serial.println(F("* Main Menu:"));
@@ -196,6 +201,7 @@ void help(uint8_t arg_cnt, char **args)
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void show_splash(uint8_t arg_cnt, char **args) {
+   (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
    //Read CAN-Bus IDs related to BMS (sniff traffic)
    byte selected[] = {0,1,2,3,4,5,6,7};
    ReadCANtraffic_BMS(selected, sizeof(selected));
@@ -222,6 +228,7 @@ void print_on_off(bool on)
 //--------------------------------------------------------------------------------
 void show_info(uint8_t arg_cnt, char **args)
 {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   //Serial.print(F("Usable Memory: ")); Serial.println(getFreeRam());
   //Serial.print(F("Menu: ")); Serial.println(myDevice.menu);
 //  Serial.print(F("    Car VIN: ")); Serial.println(BMS.CarVIN);
@@ -317,6 +324,7 @@ void init_cmd_prompt() {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void main_menu (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   myDevice.menu = MAIN;
   init_cmd_prompt();
 }
@@ -409,6 +417,7 @@ void cs_sub (uint8_t arg_cnt, char **args) {
 //--------------------------------------------------------------------------------
 void reset_factory_defaults(uint8_t arg_cnt, char **args)
 {
+  (void) arg_cnt, (void) args;  // avoid -Wunusedparameter warning
   ReadGlobalConfig(&myDevice, true);
 }
 

--- a/ED_BMSdiag/ED_BMSdiag_CLI.ino
+++ b/ED_BMSdiag/ED_BMSdiag_CLI.ino
@@ -282,7 +282,7 @@ void set_initial_dump(uint8_t arg_cnt, char **args) {
     if (strcmp(args[1], "off") == 0) {
       myDevice.initialDump = false;
     }
-    EEPROM.update(EE_IntialDumpAll, myDevice.initialDump);
+    EEPROM.update(EE_InitialDumpAll, myDevice.initialDump);
   } else {
     if (arg_cnt == 1) {
       show_info(arg_cnt, args);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Get the hardware and use an appropriate cable for the physical connection. See t
 * **Find detailed installation instructions in: [english](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation) | [german](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation_DE).**
 
 > **Verified to work with Arduino IDE 1.8.4 (on OS X 10.12 and WIN-Systems)**
+
 > **Verified to work with Arduino IDE 1.8.5 (on OS X 10.13)**
 
 ## Usage >on your own risk<

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # ED BMSdiag
 
-[![version](https://img.shields.io/badge/version-v1.0.4-blue.svg)](https://github.com/MyLab-odyssey/ED_BMSdiag/archive/master.zip)
+[![version](https://img.shields.io/badge/version-v1.0.5-blue.svg)](https://github.com/MyLab-odyssey/ED_BMSdiag/archive/master.zip)
 [![version](https://img.shields.io/badge/issues-none-brightgreen.svg)](https://github.com/MyLab-odyssey/ED_BMSdiag/issues)
-[![release](https://img.shields.io/badge/release-v1.0.4-brightgreen.svg)](https://github.com/MyLab-odyssey/ED_BMSdiag/releases)
+[![release](https://img.shields.io/badge/release-v1.0.5-brightgreen.svg)](https://github.com/MyLab-odyssey/ED_BMSdiag/releases)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/MyLab-odyssey/ED_BMSdiag/blob/master/LICENSE.txt)
 
 Retrieve battery diagnostic data from your smart electric drive EV. Get a Status Report to rate the health of the battery or dig into more detailed measurements.  
 
 >**Further documentation in the [Wiki](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki).**
 
->**The development is now basically finished with the final release of v1.0.4 .**  
+>**The development is now basically finished with the final release of v1.0.5 .**  
 
 >**The software will only work on the third generation Smart electric drive vehicle build from late 2012 to mid 2015.**
 
@@ -52,6 +52,8 @@ This simple tool will display the diagnostics via a serial USB connection. The r
 ## Version history
 |version  | comment|
 |-------- | --------|
+|v1.0.5   | Internal:|
+|         | ... Eliminate compiler warnings throughout the code. Two warnings remain, but are in the EEPROM library|
 |v1.0.4   | Feature:|
 |         | ... When battery SOH flags show "DEGRADED", output individual flags|
 |v1.0.3   | Small improvement:|

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Get the hardware and use an appropriate cable for the physical connection. See t
 
 * Open the ED_BMSdiag.ino file and compile / upload it to the Arduino board.  
 
-* **Find detailed installation instructions in: [english](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation) | [german](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation_DE).**
+* **Find detailed installation instructions in: [english](wiki/Installation) | [german](wiki/Installation_DE).**
 
 > **Verified to work with Arduino IDE 1.8.4 (on OS X 10.12 and WIN-Systems)**
 
@@ -42,7 +42,7 @@ Get the hardware and use an appropriate cable for the physical connection. See t
 ## Usage >on your own risk<
 Connect the CAN shield to the OBDII-connector and power up the car.
 
-This simple tool will display the diagnostics via a serial USB connection. The readout will be started by entering commands after the prompt. See the [Wiki for further details of the CLI](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Command-Line-Interface).
+This simple tool will display the diagnostics via a serial USB connection. The readout will be started by entering commands after the prompt. See the [Wiki for further details of the CLI](wiki/Command-Line-Interface).
 
 
 >**You need to open the serial monitor of the Arduino-IDE.  Verify that it is set to CR = Carriage Return and the baud rate is 115200.**

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Get the hardware and use an appropriate cable for the physical connection. See t
 
 * Open the ED_BMSdiag.ino file and compile / upload it to the Arduino board.  
 
-* **Find detailed installation instructions in: [english](wiki/Installation) | [german](wiki/Installation_DE).**
+* **Find detailed installation instructions in: [english](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation) | [german](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation_DE).**
 
 > **Verified to work with Arduino IDE 1.8.4 (on OS X 10.12 and WIN-Systems)**
 
@@ -42,7 +42,7 @@ Get the hardware and use an appropriate cable for the physical connection. See t
 ## Usage >on your own risk<
 Connect the CAN shield to the OBDII-connector and power up the car.
 
-This simple tool will display the diagnostics via a serial USB connection. The readout will be started by entering commands after the prompt. See the [Wiki for further details of the CLI](wiki/Command-Line-Interface).
+This simple tool will display the diagnostics via a serial USB connection. The readout will be started by entering commands after the prompt. See the [Wiki for further details of the CLI](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Command-Line-Interface).
 
 
 >**You need to open the serial monitor of the Arduino-IDE.  Verify that it is set to CR = Carriage Return and the baud rate is 115200.**

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Get the hardware and use an appropriate cable for the physical connection. See t
 * **Find detailed installation instructions in: [english](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation) | [german](https://github.com/MyLab-odyssey/ED_BMSdiag/wiki/Installation_DE).**
 
 > **Verified to work with Arduino IDE 1.8.4 (on OS X 10.12 and WIN-Systems)**
+> **Verified to work with Arduino IDE 1.8.5 (on OS X 10.13)**
 
 ## Usage >on your own risk<
 Connect the CAN shield to the OBDII-connector and power up the car.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,8 @@
 ## ED BMSdiag version history
 |version  | comment|
 |-------- | --------|
+|v1.0.5   | Internal:|
+|         | ... Eliminate compiler warnings throughout the code. Two warnings remain, but are in the EEPROM library|
 |v1.0.4   | Feature:|
 |         | ... When battery SOH flags show "DEGRADED", output individual flags|
 |v1.0.3   | Small improvement:|


### PR DESCRIPTION
Hi, 
I created a PR with support for the following features (working):
1. Support for automatically dumping all data to the serial port upon initial connection to the CAN bus. This is to save the occassional user from having to remember what to type; it becomes plug USB, open serial port, plug CAN, auto-download, done.
2. Saves user configuration (whether logging is enabled, what frequency, whether initial auto-dump is configured) to the AVR EEPROM so that the next connection comes up in the same state as the device was left in. (If you've done "log on 10", upon next connection, "log on 10" is automatically activated.)
3. Bumped the master version to 1.0.2.

And preliminary work towards supporting fetching the Car VIN (as distinct from battery VIN), but this is not yet working [though causes no negative effects].